### PR TITLE
Fix duplicate genre on searchBookByAuthorAsync

### DIFF
--- a/ABCDoubleE.API/ABCDoubleE.API.sln
+++ b/ABCDoubleE.API/ABCDoubleE.API.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.002.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ABCDoubleE.API", "ABCDoubleE.API.csproj", "{5B9703EC-0439-43BF-93D8-A89FCB53EB57}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{5B9703EC-0439-43BF-93D8-A89FCB53EB57}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5B9703EC-0439-43BF-93D8-A89FCB53EB57}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5B9703EC-0439-43BF-93D8-A89FCB53EB57}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5B9703EC-0439-43BF-93D8-A89FCB53EB57}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {00E44265-82CA-4CB3-9299-F350D3C3B364}
+	EndGlobalSection
+EndGlobal

--- a/ABCDoubleE.Controllers/GenreController.cs
+++ b/ABCDoubleE.Controllers/GenreController.cs
@@ -33,7 +33,7 @@ namespace ABCDoubleE.Controllers
         [HttpGet]
         [Route("search")]
         [ProducesResponseType(typeof(List<Genre>), 200)]
-        public async Task<IActionResult> SearchGenres([FromQuery] string search)
+        public async Task<IActionResult> SearchGenres([FromQuery] string search = "")
         {
             if (string.IsNullOrWhiteSpace(search))
             {

--- a/ABCDoubleE.Services/DatabaseLookupService.cs
+++ b/ABCDoubleE.Services/DatabaseLookupService.cs
@@ -47,4 +47,39 @@ public class DatabaseLookupService
 
         return newGenre;
     }
+
+    // New methods to add and track entities without immediate save
+    public void TrackNewGenre(Genre genre) => _context.Genres.Add(genre);
+    public void TrackNewAuthor(Author author) => _context.Authors.Add(author);
+    public void TrackNewBook(Book book) => _context.Books.Add(book);
+
+    // Final save method to persist all changes at once
+    public async Task SaveChangesAsync() => await _context.SaveChangesAsync();
+
+     // Check or add genre if not exists
+    // Check or add genre if not exists, save immediately if new
+    public async Task<Genre> GetOrAddGenreAsync(string name)
+    {
+        var genre = await GetExistingGenreAsync(name) ?? new Genre { name = name };
+        if (genre.genreId == 0)
+        {
+            _context.Genres.Add(genre);
+            await _context.SaveChangesAsync(); // Save immediately to get the genreId
+        }
+        return genre;
+    }
+
+    // Check or add author if not exists, save immediately if new
+    public async Task<Author> GetOrAddAuthorAsync(string name)
+    {
+        var author = await GetExistingAuthorAsync(name) ?? new Author { name = name };
+        if (author.authorId == 0)
+        {
+            _context.Authors.Add(author);
+            await _context.SaveChangesAsync(); // Save immediately to get the authorId
+        }
+        return author;
+    }
+
+
 }


### PR DESCRIPTION
Previous code doesn't save change until the end, which leads to potential duplicate in author and genre. 
Solution: 
add cache to keep track of book, genre, author added during this search.
saveChange right away for author and genre. 